### PR TITLE
Fix #hash and #inspect arity under rbx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'adamantium', :git => 'https://github.com/mbj/adamantium.git', :branch => :'no-deep-freeze-etc'
 gem 'backports', '~> 2.6.1'
 
 group :development do

--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -55,7 +55,7 @@ private
   # @api private
   def define_hash_method
     keys = @keys
-    define_method(:hash) do
+    define_method(:hash) do ||
       keys.map { |key| send(key).hash }.reduce(self.class.hash, :^)
     end
   end
@@ -67,7 +67,7 @@ private
   # @api private
   def define_inspect_method
     keys = @keys
-    define_method(:inspect) do
+    define_method(:inspect) do ||
       klass = self.class
       name  = klass.name || klass.inspect
       "#<#{name}#{keys.map { |key| " #{key}=#{send(key).inspect}" }.join}>"

--- a/spec/unit/class_method/new_spec.rb
+++ b/spec/unit/class_method/new_spec.rb
@@ -62,6 +62,10 @@ describe Equalizer, '.new' do
 
     describe '#inspect' do
       it { instance.inspect.should eql('#<User>') }
+
+      it 'is a method with zero arity' do
+        instance.method(:inspect).arity.should be(0)
+      end
     end
   end
 
@@ -125,6 +129,10 @@ describe Equalizer, '.new' do
 
     describe '#hash' do
       it { instance.hash.should eql(klass.hash ^ first_name.hash) }
+
+      it 'is a method with zero arity' do
+        instance.method(:hash).arity.should be(0)
+      end
 
       it 'memoizes the hash code' do
         instance.hash.should eql(instance.memoized(:hash))


### PR DESCRIPTION
This small rbx specific change is needed to make sure equalizer works well with dkubb/adamantium#4.

Only pull when the no-deep-freeze-etc branch was merged.
