### PR TITLE
Restore Ruby 1.8.7 compatibility

### DIFF
--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -53,7 +53,7 @@ private
   def define_cmp_method
     keys = @keys
     define_method(:cmp?) do |comparator, other|
-      keys.all? { |key| send(key).public_send(comparator, other.send(key)) }
+      keys.all? { |key| send(key).send(comparator, other.send(key)) }
     end
     private :cmp?
   end


### PR DESCRIPTION
It’s unclear to me why you started calling `public_send` instead of `send` here but it breaks Ruby 1.8.7 compatibility in all dependent gems. I know you don’t actively test again Ruby 1.8.7 and it’s not technically supported but I’d appreciate it if you merged this simple change to restore compatibility.
