### PR TITLE
Fix use of coerce method

### DIFF
--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -112,7 +112,7 @@ private
     #
     # @api public
     def ==(other)
-      other = coerce(other) if respond_to?(:coerce, true)
+      other = coerce(other).first if respond_to?(:coerce, true)
       other.is_a?(self.class) && cmp?(__method__, other)
     end
   end # module Methods

--- a/spec/unit/equalizer/methods/equality_operator_spec.rb
+++ b/spec/unit/equalizer/methods/equality_operator_spec.rb
@@ -83,7 +83,7 @@ describe Equalizer::Methods, '#==' do
       # declare a private #coerce method
       described_class.class_eval do
         def coerce(other)
-          self.class.new(!!other)
+          [self.class.new(!!other), self]
         end
         private :coerce
       end


### PR DESCRIPTION
Hey there!

The gem's use of the #coerce method does not comport with the API as established by Ruby itself (e.g. [Numeric#coerce](http://ruby-doc.org/core-1.9.3/Numeric.html#method-i-coerce)).

This tweaks the usage of the return value to conform to the standard API.