### PR TITLE
Ensure coerced value is an array

### DIFF
--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -114,7 +114,7 @@ private
     #
     # @api public
     def ==(other)
-      other = coerce(other).first if respond_to?(:coerce, true)
+      other = Array(coerce(other)).first if respond_to?(:coerce, true)
       other.kind_of?(self.class) && cmp?(__method__, other)
     end
   end # module Methods

--- a/spec/unit/equalizer/methods/equality_operator_spec.rb
+++ b/spec/unit/equalizer/methods/equality_operator_spec.rb
@@ -96,6 +96,26 @@ describe Equalizer::Methods, '#==' do
     end
   end
 
+  context 'with a same object after coercion' do
+    let(:other) { Object.new }
+
+    before do
+      # declare a private #coerce method
+      described_class.class_eval do
+        def coerce(other)
+          self
+        end
+        private :coerce
+      end
+    end
+
+    it { should be(true) }
+
+    it 'is not symmetric' do
+      should_not eql(other == object)
+    end
+  end
+
   context 'with a different object after coercion' do
     let(:other) { nil }
 


### PR DESCRIPTION
Sometimes custom implementations of `coerce` method might return
non-array values. That will cause an error "undefined method 'first'..."
to be raised.

One of examples of that implementation is Virtus gem:
https://github.com/solnic/virtus/blob/8d8755fda36260a84529734de8b3c4c630c69211/lib/virtus/attribute/coercer.rb#L34
