### PR TITLE
Remove the call to #module_eval in #included hook

### DIFF
--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -30,7 +30,7 @@ private
   # @api private
   def included(descendant)
     super
-    descendant.module_eval { include Methods }
+    descendant.include Methods
   end
 
   # Define the equalizer methods based on #keys


### PR DESCRIPTION
For it seems to be redundant here.