### PR TITLE
Add a timeout for running Rspec examples

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expect_with|
     expect_with.syntax = :expect
   end
+
+  config.around(:each) do |example|
+    Timeout.timeout(5_000, &example)
+  end
 end


### PR DESCRIPTION
It is just a copy of the snippet from https://github.com/mbj/mutant/#configuration.

Without it, there is a mutation running indefinitely:
```
Mutant configuration:
Matcher:         #<Mutant::Matcher::Config match_expressions: [Equalizer*]>
Integration:     Mutant::Integration::Rspec
Expect Coverage: 100.00%
Jobs:            2
Includes:        ["lib"]
Requires:        ["equalizer"]
Subjects:        8
Mutations:       338
Kills:           337
Alive:           0
Runtime:         444.58s
Killtime:        31.13s
Overhead:        1328.07%
Coverage:        100.00%
Expected:        100.00%
Active Jobs:
174: evil:Equalizer#define_inspect_method:/home/home/ch1c0t/sources/ruby/equalizer/lib/equalizer.rb:79:70cf0
Active subjects: 1
Equalizer#define_inspect_method:/home/home/ch1c0t/sources/ruby/equalizer/lib/equalizer.rb:79 mutations: 87
......................................................................................
(86/87) 100% - killtime: 11.55s runtime: 11.55s overhead: 0.00s
```