### PR TITLE
Define the methods(:cmp?, :hash, :inspect) without metaprogramming

### DIFF
--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # Define equality, equivalence and inspection methods
-class Equalizer < Module
+module Equalizer
   # Initialize an Equalizer with the given keys
   #
   # Will use the keys with which it is initialized to define #cmp?,
@@ -9,84 +9,34 @@ class Equalizer < Module
   #
   # @param [Array<Symbol>] keys
   #
-  # @return [undefined]
+  # @return [Module]
   #
-  # @api private
-  def initialize(*keys)
-    @keys = keys
-    define_methods
-    freeze
-  end
-
-private
-
-  # Hook called when module is included
-  #
-  # @param [Module] descendant
-  #   the module or class including Equalizer
-  #
-  # @return [self]
-  #
-  # @api private
-  def included(descendant)
-    super
-    descendant.include Methods
-  end
-
-  # Define the equalizer methods based on #keys
-  #
-  # @return [undefined]
-  #
-  # @api private
-  def define_methods
-    define_cmp_method
-    define_hash_method
-    define_inspect_method
-  end
-
-  # Define an #cmp? method based on the instance's values identified by #keys
-  #
-  # @return [undefined]
-  #
-  # @api private
-  def define_cmp_method
-    keys = @keys
-    define_method(:cmp?) do |comparator, other|
-      keys.all? do |key|
-        __send__(key).public_send(comparator, other.__send__(key))
-      end
-    end
-    private :cmp?
-  end
-
-  # Define a #hash method based on the instance's values identified by #keys
-  #
-  # @return [undefined]
-  #
-  # @api private
-  def define_hash_method
-    keys = @keys
-    define_method(:hash) do | |
-      keys.map(&method(:send)).push(self.class).hash
-    end
-  end
-
-  # Define an inspect method that reports the values of the instance's keys
-  #
-  # @return [undefined]
-  #
-  # @api private
-  def define_inspect_method
-    keys = @keys
-    define_method(:inspect) do | |
-      klass = self.class
-      name  = klass.name || klass.inspect
-      "#<#{name}#{keys.map { |key| " #{key}=#{__send__(key).inspect}" }.join}>"
-    end
+  # @api public
+  def self.new(*keys)
+    Module.new do
+      define_method(:keys) { keys }
+      include Methods
+    end.freeze
   end
 
   # The comparison methods
   module Methods
+    private def cmp?(comparator, other)
+      keys.all? do |key|
+        __send__(key).public_send(comparator, other.__send__(key))
+      end
+    end
+
+    def hash
+      keys.map(&method(:send)).push(self.class).hash
+    end
+
+    def inspect
+      klass = self.class
+      name  = klass.name || klass.inspect
+      "#<#{name}#{keys.map { |key| " #{key}=#{__send__(key).inspect}" }.join}>"
+    end
+
     # Compare the object with other object for equality
     #
     # @example

--- a/lib/equalizer/version.rb
+++ b/lib/equalizer/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-class Equalizer < Module
+module Equalizer
   # Gem version
   VERSION = '0.0.11'.freeze
 end # class Equalizer


### PR DESCRIPTION
It is not ready to merge. Just want to get some feedback about the idea.

It fails 6 examples:
```
rspec ./spec/unit/equalizer/universal_spec.rb:101 # Equalizer.new with keys should be an instance of Equalizer
rspec ./spec/unit/equalizer/universal_spec.rb:105 # Equalizer.new with keys defines #hash and #inspect methods dynamically
rspec ./spec/unit/equalizer/universal_spec.rb:21 # Equalizer.new with no keys should be an instance of Equalizer
rspec ./spec/unit/equalizer/universal_spec.rb:25 # Equalizer.new with no keys defines #hash and #inspect methods dynamically
rspec ./spec/unit/equalizer/included_spec.rb:46 # Equalizer#included includes methods into the descendant
rspec ./spec/unit/equalizer/included_spec.rb:27 # Equalizer#included delegates to the superclass #included method
```
But all of them seem to be testing the internal details of implementation. 