### PR TITLE
Allow #inspect method to be disabled with a switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ point_a == point_c           # => false
 point_a.hash == point_c.hash # => false
 point_a.eql?(point_c)        # => false
 point_a.equal?(point_c)      # => false
+
+class Person < Struct.new(:id, :name)
+  include Equalizer.new(:id, define_inspect: false)
+end
+
+amy = Person.new(1, "Amy")
+
+amy.inspect   # => '#<struct Person id=1, name="Amy">'
 ```
 
 Supported Ruby Versions

--- a/lib/equalizer.rb
+++ b/lib/equalizer.rb
@@ -8,13 +8,15 @@ class Equalizer < Module
   # #hash, and #inspect
   #
   # @param [Array<Symbol>] keys
+  # @param define_inspect [Boolean] whether to override #inspect
   #
   # @return [undefined]
   #
   # @api private
-  def initialize(*keys)
+  def initialize(*keys, define_inspect: true)
     @keys = keys
-    define_methods
+    define_cmp_and_hash_methods
+    define_inspect_method if define_inspect
     freeze
   end
 
@@ -38,10 +40,9 @@ private
   # @return [undefined]
   #
   # @api private
-  def define_methods
+  def define_cmp_and_hash_methods
     define_cmp_method
     define_hash_method
-    define_inspect_method
   end
 
   # Define an #cmp? method based on the instance's values identified by #keys

--- a/spec/unit/equalizer/universal_spec.rb
+++ b/spec/unit/equalizer/universal_spec.rb
@@ -155,4 +155,36 @@ describe Equalizer, '.new' do
       end
     end
   end
+
+  context 'when define_inspect: false is specified' do
+    subject { object.new(*keys, define_inspect: false) }
+
+    let(:keys)       { %i[firstname lastname].freeze  }
+    let(:firstname)  { 'John'                         }
+    let(:lastname)   { 'Doe'                          }
+    let(:instance)   { klass.new(firstname, lastname) }
+
+    let(:klass) do
+      ::Class.new do
+        attr_reader :firstname, :lastname
+        private :firstname, :lastname
+
+        def initialize(firstname, lastname)
+          @firstname = firstname
+          @lastname = lastname
+        end
+      end
+    end
+
+    before do
+      # specify the class #inspect method
+      allow(klass).to receive_messages(name: nil, inspect: name)
+      klass.send(:include, subject)
+    end
+
+    it 'does not define a new #inspect method synamically' do
+      expect(subject.public_instance_methods(false).map(&:to_s))
+        .not_to include('inspect')
+    end
+  end
 end


### PR DESCRIPTION
Defining equality based only on e.g. an `id` attribute, even when other attributes exist on a class, is a common pattern (see ActiveRecord). But in this case, Equalizer defines `#inspect` to show only the keys provided to it.

This patch allows you to disable this behaviour and keep the original `#inspect` method.