### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/equalizer.gemspec
+++ b/equalizer.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.licenses = "MIT"
 
   gem.require_paths = %w[lib]
-  gem.files = `git ls-files`.split("\n")
+  gem.files = `git ls-files`.split("\n").grep_v(%r{^spec/})
   gem.extra_rdoc_files = %w[LICENSE README.md CONTRIBUTING.md]
 
   gem.required_ruby_version = ">= 3.1"


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 11776 bytes
after:  9728 bytes
```
